### PR TITLE
Resize and fit all images to template

### DIFF
--- a/app_enhanced.py
+++ b/app_enhanced.py
@@ -841,7 +841,7 @@ class EnhancedComicGenerator:
         .comic-container { max-width: 1200px; margin: 0 auto; }
         .comic-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 30px; margin-top: 30px; }
         .comic-panel { background: white; border: 4px solid #333; box-shadow: 0 5px 20px rgba(0,0,0,0.3); position: relative; overflow: hidden; }
-        .comic-panel img { width: 100%; height: 400px; object-fit: cover; display: block; }
+        .comic-panel img { width: 100%; height: 400px; object-fit: contain; background:#000; display: block; }
         .panel-info { position: absolute; bottom: 0; left: 0; right: 0; background: rgba(0,0,0,0.8); color: white; padding: 15px; }
         .panel-text { font-size: 14px; margin-bottom: 8px; line-height: 1.4; }
         .emotion-badges { display: flex; gap: 10px; font-size: 12px; }
@@ -1067,9 +1067,9 @@ class EnhancedComicGenerator:
             width: 100%;
             height: 100%;
             display: block; /* Remove baseline gap */
-            object-fit: cover; /* Fill without letterboxing */
+            object-fit: contain; /* Preserve full image, no cropping */
             object-position: center; /* Center the image */
-            background-color: transparent;
+            background-color: #000; /* Subtle letterbox bars rather than crop */
         }
         
         /* Alternative modes - uncomment one to use */

--- a/app_enhanced.py
+++ b/app_enhanced.py
@@ -220,6 +220,8 @@ class EnhancedComicGenerator:
             
             # 10. Save results
             print("💾 Saving results...")
+            # Prepare exact-size panel images to avoid any gaps in HTML
+            self._generate_panel_frames_400x540()
             self._save_results(pages)
             
             # 11. Smart mode already applied during frame selection
@@ -257,6 +259,38 @@ class EnhancedComicGenerator:
             enhancer.enhance_batch(self.frames_dir)
         except Exception as e:
             print(f"❌ Simple enhancement failed: {e}")
+    
+    def _generate_panel_frames_400x540(self):
+        """Create 400x540 PNG versions for all frames to avoid gaps in UI."""
+        try:
+            target_w, target_h = 400, 540
+            input_dir = self.frames_dir
+            output_dir = os.path.join('frames', 'panels_400x540')
+            os.makedirs(output_dir, exist_ok=True)
+            frame_files = [f for f in os.listdir(input_dir) if f.lower().endswith('.png')]
+            for fname in frame_files:
+                src_path = os.path.join(input_dir, fname)
+                dst_name = os.path.splitext(fname)[0] + '.png'
+                dst_path = os.path.join(output_dir, dst_name)
+                try:
+                    img = cv2.imread(src_path)
+                    if img is None:
+                        continue
+                    h, w = img.shape[:2]
+                    scale = max(target_w / w, target_h / h)
+                    new_w = int(round(w * scale))
+                    new_h = int(round(h * scale))
+                    resized = cv2.resize(img, (new_w, new_h), interpolation=cv2.INTER_LANCZOS4)
+                    x_start = max(0, (new_w - target_w) // 2)
+                    y_start = max(0, (new_h - target_h) // 2)
+                    cropped = resized[y_start:y_start+target_h, x_start:x_start+target_w]
+                    cropped = cropped[:target_h, :target_w]
+                    cv2.imwrite(dst_path, cropped, [cv2.IMWRITE_PNG_COMPRESSION, 3])
+                except Exception as e:
+                    print(f"⚠️ 400x540 generation failed for {fname}: {e}")
+            print(f"✅ 400x540 frames ready in {output_dir}")
+        except Exception as e:
+            print(f"⚠️ Failed generating 400x540 frames: {e}")
     
     def _enhance_all_images_advanced(self):
         """Enhance quality using advanced AI models (Real-ESRGAN, GFPGAN, etc.)"""
@@ -845,7 +879,7 @@ class EnhancedComicGenerator:
             
             html += f'''
             <div class="comic-panel">
-                <img src="/frames/final/{panel['frame']}" alt="Panel {i+1}" onerror="this.src='/frames/final/frame{i:03d}.png'">
+                <img src="/frames/panels_400x540/{panel['frame']}" alt="Panel {i+1}" onerror="this.src='/frames/panels_400x540/frame{i:03d}.png'">
                 <div class="match-score {match_class}">
                     Match: {match_score:.1%} | Eyes: {panel.get('eye_score', 1.0):.1%}
                 </div>
@@ -974,6 +1008,7 @@ class EnhancedComicGenerator:
             position: absolute;
             top: 0;
             left: 0;
+            border: none;
         }
         .page-wrapper {
             margin: 30px auto;
@@ -1019,38 +1054,22 @@ class EnhancedComicGenerator:
         }
         .panel { 
             position: relative; 
-            border: 1px solid #333;
+            border: none;
             overflow: hidden; 
             width: 400px;
             height: 540px;
-            box-sizing: border-box; /* Border included in dimensions */
+            box-sizing: border-box; /* Keep sizing consistent */
             margin: 0;
             padding: 0;
             flex-shrink: 0; /* Don't shrink */
         }
-        /* Remove double borders between adjacent panels */
-        .panel:nth-child(1) {
-            border-right: none;
-            border-bottom: none;
-        }
-        .panel:nth-child(2) {
-            border-left: 1px solid #333;
-            border-bottom: none;
-        }
-        .panel:nth-child(3) {
-            border-right: none;
-            border-top: 1px solid #333;
-        }
-        .panel:nth-child(4) {
-            border-left: 1px solid #333;
-            border-top: 1px solid #333;
-        }
         .panel img { 
-            width: 100%; 
-            height: 100%; 
-            object-fit: contain; /* No zooming - shows entire image */
+            width: 100%;
+            height: 100%;
+            display: block; /* Remove baseline gap */
+            object-fit: cover; /* Fill without letterboxing */
             object-position: center; /* Center the image */
-            background-color: #fff; /* White background for letterbox areas */
+            background-color: transparent;
         }
         
         /* Alternative modes - uncomment one to use */
@@ -1059,21 +1078,12 @@ class EnhancedComicGenerator:
         /* .panel img { object-fit: scale-down; } */ /* Shrink if needed */
         
         /* Exact 800x1080 mode - no individual borders */
-        .exact-size .panel { 
-            border: none !important; 
-        }
-        .exact-size .comic-grid { 
-            border: 1px solid #333;
-            box-sizing: border-box;
-        }
+        .exact-size .panel { border: none !important; }
+        .exact-size .comic-grid { border: none !important; box-sizing: border-box; }
         
         /* Unity export mode - no borders, clean images */
-        .unity-export .panel { 
-            border: none !important; 
-        }
-        .unity-export .comic-grid { 
-            border: none !important; 
-        }
+        .unity-export .panel { border: none !important; }
+        .unity-export .comic-grid { border: none !important; }
         .unity-export .page-info {
             display: none !important;
         }
@@ -1240,7 +1250,7 @@ class EnhancedComicGenerator:
                                 panelDiv.className = 'panel';
                                 
                                 const img = document.createElement('img');
-                                img.src = '/frames/final/' + panel.image;
+                                img.src = '/frames/panels_400x540/' + panel.image;
                                 img.alt = `Page ${pageIndex + 1} - Panel ${index + 1}`;
                                 img.onerror = function() {
                                     this.style.display = 'none';
@@ -1894,6 +1904,11 @@ def output_file(filename):
 def frame_file(filename):
     """Serve frame files"""
     return send_from_directory('frames/final', filename)
+
+@app.route('/frames/panels_400x540/<path:filename>')
+def frame_panel_file(filename):
+    """Serve pre-cropped 400x540 panel frames"""
+    return send_from_directory('frames/panels_400x540', filename)
 
 @app.route('/comic')
 def view_comic():

--- a/app_enhanced.py
+++ b/app_enhanced.py
@@ -221,7 +221,7 @@ class EnhancedComicGenerator:
             # 10. Save results
             print("💾 Saving results...")
             # Prepare exact-size panel images to avoid any gaps in HTML
-            self._generate_panel_frames_400x540()
+            self._generate_panel_frames_800x540()
             self._save_results(pages)
             
             # 11. Smart mode already applied during frame selection
@@ -260,12 +260,12 @@ class EnhancedComicGenerator:
         except Exception as e:
             print(f"❌ Simple enhancement failed: {e}")
     
-    def _generate_panel_frames_400x540(self):
-        """Create 400x540 PNG versions for all frames to avoid gaps in UI."""
+    def _generate_panel_frames_800x540(self):
+        """Create 800x540 PNG versions for all frames to avoid gaps in UI."""
         try:
-            target_w, target_h = 400, 540
+            target_w, target_h = 800, 540
             input_dir = self.frames_dir
-            output_dir = os.path.join('frames', 'panels_400x540')
+            output_dir = os.path.join('frames', 'panels_800x540')
             os.makedirs(output_dir, exist_ok=True)
             frame_files = [f for f in os.listdir(input_dir) if f.lower().endswith('.png')]
             for fname in frame_files:
@@ -287,10 +287,10 @@ class EnhancedComicGenerator:
                     cropped = cropped[:target_h, :target_w]
                     cv2.imwrite(dst_path, cropped, [cv2.IMWRITE_PNG_COMPRESSION, 3])
                 except Exception as e:
-                    print(f"⚠️ 400x540 generation failed for {fname}: {e}")
-            print(f"✅ 400x540 frames ready in {output_dir}")
+                    print(f"⚠️ 800x540 generation failed for {fname}: {e}")
+            print(f"✅ 800x540 frames ready in {output_dir}")
         except Exception as e:
-            print(f"⚠️ Failed generating 400x540 frames: {e}")
+            print(f"⚠️ Failed generating 800x540 frames: {e}")
     
     def _enhance_all_images_advanced(self):
         """Enhance quality using advanced AI models (Real-ESRGAN, GFPGAN, etc.)"""
@@ -879,7 +879,7 @@ class EnhancedComicGenerator:
             
             html += f'''
             <div class="comic-panel">
-                <img src="/frames/panels_400x540/{panel['frame']}" alt="Panel {i+1}" onerror="this.src='/frames/panels_400x540/frame{i:03d}.png'">
+                <img src="/frames/panels_800x540/{panel['frame']}" alt="Panel {i+1}" onerror="this.src='/frames/panels_800x540/frame{i:03d}.png'">
                 <div class="match-score {match_class}">
                     Match: {match_score:.1%} | Eyes: {panel.get('eye_score', 1.0):.1%}
                 </div>
@@ -1250,7 +1250,7 @@ class EnhancedComicGenerator:
                                 panelDiv.className = 'panel';
                                 
                                 const img = document.createElement('img');
-                                img.src = '/frames/panels_400x540/' + panel.image;
+                                img.src = '/frames/panels_800x540/' + panel.image;
                                 img.alt = `Page ${pageIndex + 1} - Panel ${index + 1}`;
                                 img.onerror = function() {
                                     this.style.display = 'none';
@@ -1905,10 +1905,10 @@ def frame_file(filename):
     """Serve frame files"""
     return send_from_directory('frames/final', filename)
 
-@app.route('/frames/panels_400x540/<path:filename>')
+@app.route('/frames/panels_800x540/<path:filename>')
 def frame_panel_file(filename):
-    """Serve pre-cropped 400x540 panel frames"""
-    return send_from_directory('frames/panels_400x540', filename)
+    """Serve pre-cropped 800x540 panel frames"""
+    return send_from_directory('frames/panels_800x540', filename)
 
 @app.route('/comic')
 def view_comic():

--- a/backend/panel_extractor.py
+++ b/backend/panel_extractor.py
@@ -1,5 +1,5 @@
 """
-Panel Extractor - Extracts and saves individual comic panels as 400x540 PNG images
+Panel Extractor - Extracts and saves individual comic panels as 800x540 PNG images
 """
 
 import os
@@ -17,7 +17,7 @@ class PanelExtractor:
             output_dir: Directory to save extracted panels
         """
         self.output_dir = output_dir
-        self.panel_size = (400, 540)  # Width x Height
+        self.panel_size = (800, 540)  # Width x Height
         
     def extract_panels_from_comic(self, pages_json_path: str = "output/pages.json", 
                                  frames_dir: str = "frames/final") -> List[str]:
@@ -220,7 +220,7 @@ class PanelExtractor:
         return cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
     
     def _resize_panel(self, panel_img: np.ndarray) -> np.ndarray:
-        """Resize panel to target size (400x540) using cover-crop (no letterboxing)."""
+        """Resize panel to target size (800x540) using cover-crop (no letterboxing)."""
         h, w = panel_img.shape[:2]
         target_w, target_h = self.panel_size
 
@@ -251,7 +251,7 @@ class PanelExtractor:
         html = '''<!DOCTYPE html>
 <html>
 <head>
-    <title>Extracted Comic Panels - 400x540</title>
+    <title>Extracted Comic Panels - 800x540</title>
     <style>
         body {
             margin: 0;
@@ -312,8 +312,8 @@ class PanelExtractor:
     </style>
 </head>
 <body>
-    <h1>📸 Extracted Comic Panels (400x540)</h1>
-    <p style="text-align: center; color: #888;">All panels have been extracted and resized to 400x540 pixels (PNG)</p>
+    <h1>📸 Extracted Comic Panels (800x540)</h1>
+    <p style="text-align: center; color: #888;">All panels have been extracted and resized to 800x540 pixels (PNG)</p>
     
     <div class="panel-grid">
 '''

--- a/backend/panel_extractor.py
+++ b/backend/panel_extractor.py
@@ -1,5 +1,5 @@
 """
-Panel Extractor - Extracts and saves individual comic panels as 640x800 images
+Panel Extractor - Extracts and saves individual comic panels as 400x540 PNG images
 """
 
 import os
@@ -17,7 +17,7 @@ class PanelExtractor:
             output_dir: Directory to save extracted panels
         """
         self.output_dir = output_dir
-        self.panel_size = (640, 800)  # Width x Height
+        self.panel_size = (400, 540)  # Width x Height
         
     def extract_panels_from_comic(self, pages_json_path: str = "output/pages.json", 
                                  frames_dir: str = "frames/final") -> List[str]:
@@ -49,7 +49,7 @@ class PanelExtractor:
         saved_panels = []
         panel_count = 0
         
-        print(f"📸 Extracting panels as {self.panel_size[0]}x{self.panel_size[1]} images...")
+        print(f"📸 Extracting panels as {self.panel_size[0]}x{self.panel_size[1]} PNG images...")
         
         # Process each page
         for page_idx, page in enumerate(pages_data):
@@ -75,8 +75,8 @@ class PanelExtractor:
                 # Resize to target size
                 panel_img = self._resize_panel(panel_img)
                 
-                # Save panel
-                filename = f"panel_{panel_count:03d}_p{page_idx+1}_{panel_idx+1}.jpg"
+                # Save panel (PNG)
+                filename = f"panel_{panel_count:03d}_p{page_idx+1}_{panel_idx+1}.png"
                 filepath = os.path.join(self.output_dir, filename)
                 
                 # Convert to RGB if needed (remove alpha channel)
@@ -85,7 +85,7 @@ class PanelExtractor:
                 elif len(panel_img.shape) == 2:
                     panel_img = cv2.cvtColor(panel_img, cv2.COLOR_GRAY2BGR)
                 
-                cv2.imwrite(filepath, panel_img, [cv2.IMWRITE_JPEG_QUALITY, 95])
+                cv2.imwrite(filepath, panel_img, [cv2.IMWRITE_PNG_COMPRESSION, 3])
                 saved_panels.append(filepath)
                 
         print(f"✅ Extracted {len(saved_panels)} panels to: {self.output_dir}")
@@ -220,35 +220,38 @@ class PanelExtractor:
         return cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
     
     def _resize_panel(self, panel_img: np.ndarray) -> np.ndarray:
-        """Resize panel to target size (640x800)"""
+        """Resize panel to target size (400x540) using cover-crop (no letterboxing)."""
         h, w = panel_img.shape[:2]
         target_w, target_h = self.panel_size
-        
-        # Calculate scale to fit within target size while maintaining aspect ratio
-        scale = min(target_w / w, target_h / h)
-        new_w = int(w * scale)
-        new_h = int(h * scale)
-        
-        # Resize image
+
+        # Scale to cover the target area
+        scale = max(target_w / w, target_h / h)
+        new_w = int(round(w * scale))
+        new_h = int(round(h * scale))
+
         resized = cv2.resize(panel_img, (new_w, new_h), interpolation=cv2.INTER_LANCZOS4)
-        
-        # Create canvas of target size
-        canvas = np.ones((target_h, target_w, 3), dtype=np.uint8) * 255  # White background
-        
-        # Center the resized image on canvas
-        x_offset = (target_w - new_w) // 2
-        y_offset = (target_h - new_h) // 2
-        
-        canvas[y_offset:y_offset+new_h, x_offset:x_offset+new_w] = resized
-        
-        return canvas
+
+        # Center crop to exact target size
+        x_start = max(0, (new_w - target_w) // 2)
+        y_start = max(0, (new_h - target_h) // 2)
+        x_end = x_start + target_w
+        y_end = y_start + target_h
+        cropped = resized[y_start:y_end, x_start:x_end]
+
+        # Safety: if rounding produced off-by-one, pad/crop to exact
+        cropped = cropped[:target_h, :target_w]
+        if cropped.shape[0] < target_h or cropped.shape[1] < target_w:
+            canvas = np.ones((target_h, target_w, 3), dtype=np.uint8) * 255
+            canvas[:cropped.shape[0], :cropped.shape[1]] = cropped
+            return canvas
+        return cropped
     
     def _create_panel_viewer(self, panel_files: List[str]):
         """Create an HTML viewer for extracted panels"""
         html = '''<!DOCTYPE html>
 <html>
 <head>
-    <title>Extracted Comic Panels - 640x800</title>
+    <title>Extracted Comic Panels - 400x540</title>
     <style>
         body {
             margin: 0;
@@ -309,8 +312,8 @@ class PanelExtractor:
     </style>
 </head>
 <body>
-    <h1>📸 Extracted Comic Panels (640x800)</h1>
-    <p style="text-align: center; color: #888;">All panels have been extracted and resized to 640x800 pixels</p>
+    <h1>📸 Extracted Comic Panels (400x540)</h1>
+    <p style="text-align: center; color: #888;">All panels have been extracted and resized to 400x540 pixels (PNG)</p>
     
     <div class="panel-grid">
 '''

--- a/backend/panel_extractor.py
+++ b/backend/panel_extractor.py
@@ -220,31 +220,23 @@ class PanelExtractor:
         return cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
     
     def _resize_panel(self, panel_img: np.ndarray) -> np.ndarray:
-        """Resize panel to target size (800x540) using cover-crop (no letterboxing)."""
+        """Resize panel to target size (800x540) using contain-and-pad (no cropping)."""
         h, w = panel_img.shape[:2]
         target_w, target_h = self.panel_size
 
-        # Scale to cover the target area
-        scale = max(target_w / w, target_h / h)
+        # Scale to fit within the target area preserving aspect ratio
+        scale = min(target_w / w, target_h / h)
         new_w = int(round(w * scale))
         new_h = int(round(h * scale))
 
         resized = cv2.resize(panel_img, (new_w, new_h), interpolation=cv2.INTER_LANCZOS4)
 
-        # Center crop to exact target size
-        x_start = max(0, (new_w - target_w) // 2)
-        y_start = max(0, (new_h - target_h) // 2)
-        x_end = x_start + target_w
-        y_end = y_start + target_h
-        cropped = resized[y_start:y_end, x_start:x_end]
-
-        # Safety: if rounding produced off-by-one, pad/crop to exact
-        cropped = cropped[:target_h, :target_w]
-        if cropped.shape[0] < target_h or cropped.shape[1] < target_w:
-            canvas = np.ones((target_h, target_w, 3), dtype=np.uint8) * 255
-            canvas[:cropped.shape[0], :cropped.shape[1]] = cropped
-            return canvas
-        return cropped
+        # Create canvas and center the resized image with black background
+        canvas = np.zeros((target_h, target_w, 3), dtype=np.uint8)
+        x_offset = (target_w - new_w) // 2
+        y_offset = (target_h - new_h) // 2
+        canvas[y_offset:y_offset+new_h, x_offset:x_offset+new_w] = resized
+        return canvas
     
     def _create_panel_viewer(self, panel_files: List[str]):
         """Create an HTML viewer for extracted panels"""

--- a/output_template/page.css
+++ b/output_template/page.css
@@ -42,7 +42,7 @@ body {
 .grid-item {
     background-position: center center;
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: cover; /* Ensure no letterboxing */
     border: 0;
     position: relative;
 }

--- a/output_template/page_place.js
+++ b/output_template/page_place.js
@@ -1,4 +1,4 @@
-path = '../frames/final/'
+path = '../frames/panels_400x540/'
 current_page = 0
 
 function placeDialogs(page) {
@@ -9,7 +9,10 @@ function placeDialogs(page) {
         gridItem.style.display = 'flex';
         gridItem.style.gridRow = 'span ' + panel.row_span;
         gridItem.style.gridColumn = 'span ' + panel.col_span;
-        gridItem.style.backgroundImage = `url("${path}${panel.image}.png")`;
+        gridItem.style.backgroundImage = `url("${path}${panel.image}")`;
+        gridItem.style.backgroundPosition = 'center center';
+        gridItem.style.backgroundRepeat = 'no-repeat';
+        gridItem.style.backgroundSize = 'cover';
 
         gridItem.innerHTML = "";
 

--- a/output_template/page_place.js
+++ b/output_template/page_place.js
@@ -12,7 +12,8 @@ function placeDialogs(page) {
         gridItem.style.backgroundImage = `url("${path}${panel.image}")`;
         gridItem.style.backgroundPosition = 'center center';
         gridItem.style.backgroundRepeat = 'no-repeat';
-        gridItem.style.backgroundSize = 'cover';
+        gridItem.style.backgroundSize = 'contain';
+        gridItem.style.backgroundColor = '#000';
 
         gridItem.innerHTML = "";
 

--- a/output_template/page_place.js
+++ b/output_template/page_place.js
@@ -1,4 +1,4 @@
-path = '../frames/panels_400x540/'
+path = '../frames/panels_800x540/'
 current_page = 0
 
 function placeDialogs(page) {


### PR DESCRIPTION
Resize all extracted comic panels to 400x540 PNGs using cover-cropping to ensure a gapless fit.

---
<a href="https://cursor.com/background-agent?bcId=bc-45b20124-fced-48f8-aea0-03a2f853799e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45b20124-fced-48f8-aea0-03a2f853799e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

